### PR TITLE
Fix invalid type definition for Collections property

### DIFF
--- a/pkg/service/bus-service.go
+++ b/pkg/service/bus-service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"log"
 
+	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/introspect"
 	"github.com/godbus/dbus/v5/prop"
 )
@@ -238,7 +239,7 @@ func dbusService(service *Service) {
 	propsSpec := map[string]map[string]*prop.Prop{
 		"org.freedesktop.Secret.Service": {
 			"Collections": {
-				Value:    []string{"/org/freedesktop/secrets/aliases/default"},
+				Value:    []dbus.ObjectPath{"/org/freedesktop/secrets/aliases/default"},
 				Writable: false,
 				Emit:     prop.EmitTrue,
 			},


### PR DESCRIPTION
Fixes:

```
juergen@shaun:~ → secret-tool store --label="mypass" user juergen
Password: ******

(secret-tool:108034): GLib-GIO-WARNING **: 14:44:32.940: Received property Collections with type as does not match expected type ao in the expected interface

```
