### PR TITLE
Fix return type for some Collections calls/properties.

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -215,10 +215,15 @@ func (client *Client) PropertyGetCollections() ([]string, error) {
 		return nil, errors.New("Error getting property 'Collections': " + err.Error())
 	}
 
-	collections, ok := variant.Value().([]string)
+	collectionspaths, ok := variant.Value().([]dbus.ObjectPath)
 
 	if !ok {
-		return nil, fmt.Errorf("invalid 'Collections' property type. Expected '[]string', got '%T'", variant.Value())
+		return nil, fmt.Errorf("invalid 'Collections' property type. Expected '[]dbus.ObjectPath', got '%T'", variant.Value())
+	}
+
+	var collections []string
+	for k := range collectionspaths {
+		collections = append(collections, string(collectionspaths[k]))
 	}
 
 	sort.Strings(collections)

--- a/pkg/client/collection.go
+++ b/pkg/client/collection.go
@@ -225,11 +225,16 @@ func (collection *Collection) PropertyGetItems() ([]string, error) {
 		return []string{}, fmt.Errorf("failed to read 'Items' property. Error: %v", err)
 	}
 
-	items, ok := variant.Value().([]string)
+	pathitems, ok := variant.Value().([]dbus.ObjectPath)
 
 	if !ok {
-		return []string{}, fmt.Errorf("expected 'Items' to be of type '[]string', got: '%T'",
+		return []string{}, fmt.Errorf("expected 'Items' to be of type '[]dbus.ObjectPath', got: '%T'",
 			variant.Value())
+	}
+
+	var items []string
+	for k := range pathitems {
+		items = append(items, string(pathitems[k]))
 	}
 
 	sort.Strings(items)

--- a/pkg/service/collection-methods.go
+++ b/pkg/service/collection-methods.go
@@ -268,11 +268,11 @@ func (collection *Collection) UpdateModified() {
 // UpdatePropertyCollections updates dbus property of this collection's items
 func (collection *Collection) UpdatePropertyCollectionItems() {
 
-	var items []string
+	var items []dbus.ObjectPath
 
 	collection.ItemsMutex.RLock()
 	for _, item := range collection.Items {
-		items = append(items, string(item.ObjectPath))
+		items = append(items, item.ObjectPath)
 	}
 	collection.ItemsMutex.RUnlock()
 

--- a/pkg/service/service-methods.go
+++ b/pkg/service/service-methods.go
@@ -246,13 +246,13 @@ func (service *Service) GetItemByPath(itemPath dbus.ObjectPath) *Item {
 // UpdatePropertyCollections updates dbus properties of Service
 func (s *Service) UpdatePropertyCollections() {
 
-	var collections []string
+	var collections []dbus.ObjectPath
 
 	s.CollectionsMutex.RLock()
 	defer s.CollectionsMutex.RUnlock()
 
 	for _, collection := range s.Collections {
-		collections = append(collections, string(collection.ObjectPath))
+		collections = append(collections, collection.ObjectPath)
 	}
 
 	PropsService.SetMust("org.freedesktop.Secret.Service",


### PR DESCRIPTION
Some software, such as go-libsecret cares about the return type of some
Collections calls and expects dbus ObjectPaths and not strings.  There
could be more occurences, but this fixes errors of the sort I'm seeing
in current go-libsecret like:

    panic: interface conversion: interface {} is []string, not []dbus.ObjectPath

    goroutine 1 [running]:
    github.com/gsterjov/go-libsecret.(*Collection).Items(0xc00015e3c0, 0x0, 0x0, 0x2301458, 0xc0011562f0, 0x22efd58)
            /go/pkg/mod/github.com/gsterjov/go-libsecret@v0.0.0-20161001094733-a6f4afe4910c/collection.go:33 +0x30e
    github.com/99designs/keyring.(*secretsKeyring).Keys(0xc0012218c0, 0x0, 0xc00119dea8, 0x4, 0x0, 0x0)
            /go/pkg/mod/github.com/cosmos/keyring@v1.1.7-0.20210622111912-ef00f8ac3d76/libsecret.go:243 +0x150
    github.com/cosmos/cosmos-sdk/crypto/keyring.keystore.List(0x22e8da0, 0xc0012218c0, 0xc00024c860, 0x1, 0x1, 0xc00024c870, 0x1, 0x1, 0x0, 0x0, ...)
            /go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.44.0/crypto/keyring/keyring.go:473 +0x4c
    github.com/cosmos/cosmos-sdk/client/keys.runListCmd(0xc00121b900, 0x2fdcde0, 0x0, 0x0, 0x0, 0x0)
            /go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.44.0/client/keys/list.go:31 +0x116
    github.com/spf13/cobra.(*Command).execute(0xc00121b900, 0x2fdcde0, 0x0, 0x0, 0xc00121b900, 0x2fdcde0)
            /go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:852 +0x472
    github.com/spf13/cobra.(*Command).ExecuteC(0xc00110aa00, 0x0, 0x0, 0xc000041818)
            /go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
    github.com/spf13/cobra.(*Command).Execute(...)
            /go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:897
    github.com/spf13/cobra.(*Command).ExecuteContext(...)
            /go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:890
    github.com/cosmos/cosmos-sdk/server/cmd.Execute(0xc00110aa00, 0xc000041818, 0x15, 0x6, 0xc000041818)
            /go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.44.0/server/cmd/execute.go:36 +0x285